### PR TITLE
Fix travis badge on crates.io

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ categories = ["encoding", "web-programming"]
 keywords = ["serde", "serialization", "hyper", "cookie", "mime"]
 
 [badges]
-travis-ci = { repository = "https://github.com/nox/hyper_serde", branch = "master" }
+travis-ci = { repository = "nox/hyper_serde", branch = "master" }
 
 [lib]
 doctest = false


### PR DESCRIPTION
Currently generate in https://crates.io/crates/hyper_serde as:

```
    <img src="https://travis-ci.org/https://github.com/nox/hyper_serde.svg?branch=master" alt="Travis CI build status for the master branch" title="Travis CI build status for the master branch">
```