### PR TITLE
Properly clamp on large len hints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hyper_serde"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Anthony Ramine <n.oxyde@gmail.com>"]
 description = "Serde support for Hyper types"
 license = "MIT/Apache-2.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -365,7 +365,7 @@ impl Deserialize for De<Headers> {
                 where V: SeqVisitor,
             {
                 // Clamp to not OOM on rogue values.
-                let capacity = cmp::max(visitor.size_hint().0, 64);
+                let capacity = cmp::min(visitor.size_hint().0, 64);
                 let mut values = Vec::with_capacity(capacity);
                 while let Some(v) = visitor.visit::<ByteBuf>()? {
                     values.push(v.into());


### PR DESCRIPTION
Should use cmp::min, not cmp::max...